### PR TITLE
getJsonAsArray extended, fix getOneColumnFromArray, PSR-3 logger methods

### DIFF
--- a/GodsDev/Backyard/Backyard.php
+++ b/GodsDev/Backyard/Backyard.php
@@ -24,7 +24,7 @@ class Backyard {
                 $this->Crypt = new BackyardCrypt($this->BackyardError);
                 $this->Geo = new BackyardGeo($this->BackyardError, $this->BackyardConf);
                 $this->Http = new BackyardHttp($this->BackyardError);
-                $this->Json = new BackyardJson($this->BackyardError);
+                $this->Json = new BackyardJson($this->BackyardError, $this->Http);
     }
 
     /**

--- a/GodsDev/Backyard/BackyardArray.php
+++ b/GodsDev/Backyard/BackyardArray.php
@@ -173,7 +173,7 @@ class BackyardArray {
                     $difference[$key] = $value;
                 } else {
                     $new_diff = $this->arrayDiffAssocRecursive($value, $array2[$key]);
-                    if ($new_diff != FALSE) {
+                    if ($new_diff != false) {
                         $difference[$key] = $new_diff;
                     }
                 }

--- a/GodsDev/Backyard/BackyardArray.php
+++ b/GodsDev/Backyard/BackyardArray.php
@@ -9,7 +9,7 @@ use GodsDev\Backyard\BackyardError;
  */
 class BackyardArray {
 
-    protected $BackyardError = NULL;
+    protected $BackyardError = null;
 
     /**
      * 
@@ -22,7 +22,7 @@ class BackyardArray {
 
     /**
      * Note http://php.net/manual/en/function.array-key-exists.php#107786
-     * If you want to take the performance advantage of isset() while keeping the NULL element correctly detected, use this:
+     * If you want to take the performance advantage of isset() while keeping the null element correctly detected, use this:
 
       if (isset(..) || array_key_exists(...))
       {

--- a/GodsDev/Backyard/BackyardArray.php
+++ b/GodsDev/Backyard/BackyardArray.php
@@ -58,7 +58,7 @@ class BackyardArray {
     /**
      * Returns array named $columnName from $myArray
      * Ignores rows where the field $columnName is not set
-     * @param array $myArray
+     * @param array $myArray at least two-dimensional
      * @param string $columnName
      * @param bool $columnAlwaysExpected default false; if true function does log the missing column in a row as an error
      * @return array
@@ -69,7 +69,7 @@ class BackyardArray {
         }
         $result = array();
         foreach ($myArray as $key => $row) {
-            if (isset($row[$columnName]) || array_key_exists($columnName, $row)) {
+            if (is_array($row) && (isset($row[$columnName]) || array_key_exists($columnName, $row))) {
                 $result[$key] = $row[$columnName];
             } elseif ($columnAlwaysExpected) {
                 $this->BackyardError->log(3, "getOneColumnFromArray: {$columnName} not in " . print_r($row, true));

--- a/GodsDev/Backyard/BackyardCrypt.php
+++ b/GodsDev/Backyard/BackyardCrypt.php
@@ -6,7 +6,7 @@ use GodsDev\Backyard\BackyardError;
 
 class BackyardCrypt {
 
-    protected $BackyardError = NULL;
+    protected $BackyardError = null;
 
     /**
      * 

--- a/GodsDev/Backyard/BackyardError.php
+++ b/GodsDev/Backyard/BackyardError.php
@@ -38,7 +38,114 @@ class BackyardError {
                 $backyardConfConstruct);
         //@todo do not use $this->BackyardConf but set the class properties right here accordingly; and also provide means to set the values otherwise later
     }
-    
+
+    /**
+     * System is unusable.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function emergency($message, array $context = array()){
+        return $this->log(0,$message,$context);
+    }
+
+    /**
+     * Action must be taken immediately.
+     *
+     * Example: Entire website down, database unavailable, etc. This should
+     * trigger the SMS alerts and wake you up.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function alert($message, array $context = array()){
+        return $this->log(1,$message,$context);
+    }
+
+    /**
+     * Critical conditions.
+     *
+     * Example: Application component unavailable, unexpected exception.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function critical($message, array $context = array()){
+        return $this->log(1,$message,$context);
+    }
+
+    /**
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function error($message, array $context = array()){
+        return $this->log(2,$message,$context);
+    }
+
+    /**
+     * Exceptional occurrences that are not errors.
+     *
+     * Example: Use of deprecated APIs, poor use of an API, undesirable things
+     * that are not necessarily wrong.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function warning($message, array $context = array()){
+        return $this->log(3,$message,$context);
+    }
+
+    /**
+     * Normal but significant events.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function notice($message, array $context = array()){
+        return $this->log(4,$message,$context);
+    }
+
+    /**
+     * Interesting events.
+     *
+     * Example: User logs in, SQL logs.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function info($message, array $context = array()){
+        return $this->log(4,$message,$context);
+    }
+
+    /**
+     * Detailed debug information.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function debug($message, array $context = array()){
+        return $this->log(5,$message,$context);
+    }
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed $level
+     * @param string $message
+     * @param array $context
+     * @return null
+     */    
 /**
  * Error_log() modified to log necessary debug information by application to its own log (common to the whole host by default).
  * 

--- a/GodsDev/Backyard/BackyardError.php
+++ b/GodsDev/Backyard/BackyardError.php
@@ -20,7 +20,7 @@ class BackyardError {
             BackyardTime $BackyardTime = null
             ) {
         $this->BackyardTime = ($BackyardTime === null)?(new BackyardTime()):$BackyardTime;        
-        $backyardConfConstruct = array_merge(                
+        $this->BackyardConf = array_merge(                
                 array(//default values
                     'logging_level'             => 5,       //log up to the level set here, default=5 = debug//logovat az do urovne zde uvedene: 0=unknown/default_call 1=fatal 2=error 3=warning 4=info 5=debug/default_setting 6=speed  //aby se zalogovala alespoň missing db musí být logování nejníže defaultně na 1 //1 as default for writing the missing db at least to the standard ErrorLog
                     'logging_level_name'        => array(0 => 'unknown', 1 => 'fatal', 'error', 'warning', 'info', 'debug', 'speed'),
@@ -36,7 +36,6 @@ class BackyardError {
                     'error_hack_from_get'       => 0,       //in this field, the value of $_GET['ERROR_HACK'] shall be set below                    
                 ),
                 $backyardConfConstruct);
-        $this->BackyardConf = $backyardConfConstruct;
         //@todo do not use $this->BackyardConf but set the class properties right here accordingly; and also provide means to set the values otherwise later
     }
     

--- a/GodsDev/Backyard/BackyardHttp.php
+++ b/GodsDev/Backyard/BackyardHttp.php
@@ -34,7 +34,7 @@ if (!function_exists('apache_request_headers')) {
 
 class BackyardHttp {
 
-    protected $BackyardError = NULL;
+    protected $BackyardError = null;
 
     /**
      * 
@@ -44,6 +44,7 @@ class BackyardHttp {
     BackyardError $BackyardError) {
         //error_log("debug: " . __CLASS__ . ' ' . __METHOD__);
         $this->BackyardError = $BackyardError;
+        //@todo set $this->post etc from $_POST, $_GET and $_SERVER to make the functions below testable in isolation
     }
 
     /**
@@ -153,7 +154,7 @@ class BackyardHttp {
      * @return array ('message_body', 'HTTP_CODE', 'CONTENT_TYPE', ['REDIRECT_URL',])
      */
     public function getData($url, $useragent = 'PHP/cURL', $timeout = 5, $customHeaders = false, $postArray = array()) {
-        $this->BackyardError->log(5, "backyard_getData({$url},{$useragent},{$timeout});", array(16));
+        $this->BackyardError->log(5, "backyard getData({$url},{$useragent},{$timeout});", array(16));
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_USERAGENT, $useragent);

--- a/GodsDev/Backyard/BackyardHttp.php
+++ b/GodsDev/Backyard/BackyardHttp.php
@@ -177,7 +177,7 @@ class BackyardHttp {
         }
 
         /* cannot be activated when in safe_mode or an open_basedir is set
-          curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
+          curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
           curl_setopt($ch, CURLOPT_MAXREDIRS, 5);
          */
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
@@ -279,7 +279,7 @@ class BackyardHttp {
         $host = $url['host'];
         $port = (isset($url['port']) ? $url['port'] : 80);
         $path = (isset($url['path']) ? $url['path'] : '/');
-        $this->BackyardError->log(4, "url: " . print_r($url, TRUE), array(16)); //debug
+        $this->BackyardError->log(4, "url: " . print_r($url, true), array(16)); //debug
 
         $request = "HEAD $path HTTP/1.1\r\n"
                 . "Host: $host\r\n"
@@ -298,7 +298,7 @@ class BackyardHttp {
             socket_write($socket, $request, strlen($request));
             $socketRead = socket_read($socket, 1024);
             $response = explode(' ', $socketRead);
-            $this->BackyardError->log(4, "HEAD HTTP response: " . print_r($response, TRUE), array(16)); //debug
+            $this->BackyardError->log(4, "HEAD HTTP response: " . print_r($response, true), array(16)); //debug
             //120427, if the result is not number, maybe the server doesn't understand HEAD, let's try GET
             if (!is_numeric($response[1])) {
                 $request = "GET $path HTTP/1.1\r\n"
@@ -308,7 +308,7 @@ class BackyardHttp {
 
                 socket_write($socket, $request, strlen($request));
                 $response = explode(' ', socket_read($socket, 1024));
-                $this->BackyardError->log(4, "GET HTTP response: " . print_r($response, TRUE), array(16)); //debug
+                $this->BackyardError->log(4, "GET HTTP response: " . print_r($response, true), array(16)); //debug
                 if (!is_numeric($response[1])) {
                     $this->BackyardError->log(3, "REQUEST = $request RETURNED RESPONSE = {$response[1]} INSTEAD OF HTTP status");
                 }
@@ -360,7 +360,7 @@ class BackyardHttp {
             socket_write($socket, $request, strlen($request));
 
             $response = explode(' ', socket_read($socket, 1024));
-            $this->BackyardError->log(4, "HTTP response: " . print_r($response, TRUE), array(16)); //debug
+            $this->BackyardError->log(4, "HTTP response: " . print_r($response, true), array(16)); //debug
         } else {
             $this->BackyardError->log(3, "socket_connect to $host $path failed", array(13)); //debug        
         }

--- a/GodsDev/Backyard/BackyardJson.php
+++ b/GodsDev/Backyard/BackyardJson.php
@@ -3,20 +3,24 @@
 namespace GodsDev\Backyard;
 
 use GodsDev\Backyard\BackyardError;
+use GodsDev\Backyard\BackyardHttp;
 
 /**
  * JSON FUNCTIONS
  */
 class BackyardJson {
 
-    protected $BackyardError = NULL;
+    protected $BackyardError = null;
+    protected $BackyardHttp = null;
 
     /**
      * 
-     * @param BackyardError $BackyardError
+     * @param BackyardError $backyardError
+     * @param BackyardHttp $backyardHttp
      */
-    public function __construct(BackyardError $BackyardError) {
-        $this->BackyardError = $BackyardError;
+    public function __construct(BackyardError $backyardError, BackyardHttp $backyardHttp) {
+        $this->BackyardError = $backyardError;
+        $this->BackyardHttp = $backyardHttp;
     }
 
     /**
@@ -49,6 +53,9 @@ class BackyardJson {
     public function outputJSON($jsonString, $exitAfterOutput = false, $logLevel = 5) {
         header("Content-type: application/json");
         $minifiedJson = $this->minifyJSON($jsonString, $logLevel);
+        if($minifiedJson === '{"status": "500", "error": "Internal error"}'){ //error output from minifyJSON
+            header("HTTP/1.1 500 Internal Server Error");
+        }
         echo($minifiedJson);
         if ($exitAfterOutput) {
             exit;
@@ -65,7 +72,7 @@ class BackyardJson {
      * @param   bool    $assoc   When TRUE, returned objects will be converted into associative arrays. 
      * @param   integer $depth   User specified recursion depth. (>=5.3) 
      * @param   integer $options Bitmask of JSON decode options. (>=5.4) 
-     * @return  array or NULL is returned if the json cannot be decoded or if the encoded data is deeper than the recursion limit. 
+     * @return  array or null is returned if the json cannot be decoded or if the encoded data is deeper than the recursion limit. 
      */
     public function jsonCleanDecode($json2decode, $assoc = false, $depth = 512, $options = 0) {
         // search and remove comments like /* */ and //
@@ -90,21 +97,14 @@ class BackyardJson {
      * @param string $url
      * @return array|bool array if cURL($url) returns JSON else false
      * 
-     * 
-     * @todo - use BackyardHttp
      */
-    public function getJsonAsArray($url) {
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $url);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 4);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-        $json = curl_exec($ch);
+    public function getJsonAsArray($url, $useragent = 'PHP/cURL', $timeout = 5, $customHeaders = false, $postArray = array()) {
+        $result = $this->BackyardHttp->getData($url, $useragent, $timeout, $customHeaders, $postArray);
+        $json = $result['message_body'];
         if (!$json) {
-            $this->BackyardError->log(2, "Curl error: " . curl_error($ch) . " on {$url}");
+            $this->BackyardError->log(2, "No content on {$url}");
             return false;
         }
-        curl_close($ch);
         $jsonArray = $this->jsonCleanDecode($json, true);
         if (!$jsonArray) {
             $this->BackyardError->log(2, "Trouble with decoding JSON from {$url}");

--- a/GodsDev/Backyard/BackyardJson.php
+++ b/GodsDev/Backyard/BackyardJson.php
@@ -54,7 +54,7 @@ class BackyardJson {
         header("Content-type: application/json");
         $minifiedJson = $this->minifyJSON($jsonString, $logLevel);
         if($minifiedJson === '{"status": "500", "error": "Internal error"}'){ //error output from minifyJSON
-            header("HTTP/1.1 500 Internal Server Error");
+            header("HTTP/1.1 500 Internal Server Error", true, 500);
         }
         echo($minifiedJson);
         if ($exitAfterOutput) {
@@ -69,7 +69,7 @@ class BackyardJson {
      * http://www.php.net/manual/en/function.json-decode.php#112735
      * 
      * @param   string  $json2decode    The json string being decoded 
-     * @param   bool    $assoc   When TRUE, returned objects will be converted into associative arrays. 
+     * @param   bool    $assoc   When true, returned objects will be converted into associative arrays. 
      * @param   integer $depth   User specified recursion depth. (>=5.3) 
      * @param   integer $options Bitmask of JSON decode options. (>=5.4) 
      * @return  array or null is returned if the json cannot be decoded or if the encoded data is deeper than the recursion limit. 

--- a/GodsDev/Backyard/BackyardMysqli.php
+++ b/GodsDev/Backyard/BackyardMysqli.php
@@ -25,7 +25,7 @@ use GodsDev\Backyard\BackyardError;
  */
 class BackyardMysqli extends \mysqli {
 
-    protected $BackyardError = NULL;
+    protected $BackyardError = null;
 
     /**
      * 
@@ -109,8 +109,7 @@ class BackyardMysqli extends \mysqli {
         //if ($ERROR_LOG_OUTPUT) {
         //    my_error_log($sql, 5, 11);
         //}
-        $result = //@
-                parent::query($sql); //parent query method called with @ operator, to supress error messages
+        $result = parent::query($sql);
         if ($this->errno != 0) {
             if ($ERROR_LOG_OUTPUT) {
                 $this->BackyardError->log(1, "{$this->errno} : {$this->error} /with query: {$sql}", array(11));

--- a/GodsDev/Backyard/Test/BackyardJsonTest.php
+++ b/GodsDev/Backyard/Test/BackyardJsonTest.php
@@ -3,6 +3,7 @@ namespace GodsDev\Backyard\Test;
 
 use GodsDev\Backyard\BackyardJson;
 use GodsDev\Backyard\BackyardError;
+use GodsDev\Backyard\BackyardHttp;
 
 
 /**
@@ -21,7 +22,8 @@ class BackyardJsonTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->object = new BackyardJson(new BackyardError(array('logging_level' => 4)));
+        $backyardError = new BackyardError(array('logging_level' => 4));
+        $this->object = new BackyardJson($backyardError, new BackyardHttp($backyardError));
     }
 
     /**
@@ -43,6 +45,18 @@ class BackyardJsonTest extends \PHPUnit_Framework_TestCase
         
         $this->assertEquals($expected, $this->object->minifyJSON($orig));
     }
+    
+    /**
+     * @covers GodsDev\Backyard\BackyardJson::minifyJSON
+     * @todo   Implement testMinifyJSON().
+     */
+    public function testMinifyJSONInvalid()
+    {
+        $orig = '"status": "1233", "text": "abc"}';
+        $expected = '{"status": "500", "error": "Internal error"}';
+        
+        $this->assertEquals($expected, $this->object->minifyJSON($orig));
+    }    
 
     /**
      * @covers GodsDev\Backyard\BackyardJson::outputJSON


### PR DESCRIPTION
getJsonAsArray uses getData and hence can use POST fields and custom HTTP headers
fix: getOneColumnFromArray handles one-dimensional values
Eight PSR-3 logger methods added
PHP constants null, true, false in lower case according to http://www.php-fig.org/psr/psr-2/ chapter 2.5
outputJSON returns HTTP 500 if failed
$backyardConfConstruct not reassigned for second time